### PR TITLE
Evitar duplicação de sobrenome

### DIFF
--- a/HostnetNameSanitizerBundle/Command/NameSanitizerCommand.php
+++ b/HostnetNameSanitizerBundle/Command/NameSanitizerCommand.php
@@ -39,6 +39,19 @@ class NameSanitizerCommand extends ModeratedCommand
         $altNames = 0;
         $output->writeln("<info>Limpando nomes...</info>");        
         foreach($names as $lead){
+            $trimmed_first = trim($lead['firstname']); 
+            $trimmed_last = trim($lead['lastname']);
+            $array_first = explode(" ",$trimmed_first);
+            $array_last = explode(" ",$trimmed_last);
+            $tamanho_last = sizeof($array_last);
+            $tamanho_first = sizeof($array_first);
+            for ($ii = $tamanho_last-1; $ii > -1; $ii-- ){
+                if ($array_last[$ii] == $array_first[$tamanho_first-1]){
+                    unset($array_first[$tamanho_first-1]);
+                    $tamanho_first--;
+                } 
+            }
+            $lead['firstname'] = implode(" ",$array_first);
             if(strpos(trim($lead['firstname']), trim($lead['lastname'])) !==false){
                 $fullName = trim($lead['firstname']);
             }else{

--- a/HostnetNameSanitizerBundle/Command/NameSanitizerCommand.php
+++ b/HostnetNameSanitizerBundle/Command/NameSanitizerCommand.php
@@ -39,8 +39,11 @@ class NameSanitizerCommand extends ModeratedCommand
         $altNames = 0;
         $output->writeln("<info>Limpando nomes...</info>");        
         foreach($names as $lead){
-            
-            $fullName = trim($lead['firstname'])." ".trim($lead['lastname']);       
+            if(strpos(trim($lead['firstname']), trim($lead['lastname'])) !==false){
+                $fullName = trim($lead['firstname']);
+            }else{
+                $fullName = trim($lead['firstname'])." ".trim($lead['lastname']);       
+            }
             $newFullName = $model->nameCase($fullName);
             $newFirstname = trim(substr($newFullName, 0, strpos($newFullName, " ")));
             $newLastname = trim(substr($newFullName, strpos($newFullName, " ")));


### PR DESCRIPTION
Esse código busca minimizar os efeitos narrados na issue #1 , buscando se o atual lastname está contido no atual firstname. Em caso positivo, o lastname é "descartado" para o resto da execução do plugin.

Está solução resolve o exemplo do "Fulano de Tal" relatado na issue. 

Porém, cabe destacar que ainda resta descoberto o caso onde o lead use apenas parcialmente seu nome completo no segundo formulário. Exemplo:

firstname: "Fulano de Tal"
lastname: "de Tal da Silva"

Neste caso o bug fix aqui proposto não será efetivo, com o novo lastname sendo salvo como "de Tal de Tal da Silva".

